### PR TITLE
Upload as form

### DIFF
--- a/server/dashboard/static/index.html
+++ b/server/dashboard/static/index.html
@@ -61,9 +61,9 @@
                     </div>
                 </form>
                 <div id="upload-uploading-box" class="hidden">
-                    <p>Uploading...</p>
+                    <p id="upload-progress-message">Uploading...</p>
                     <br>
-                    <img src="loading.gif"/>
+                    <progress id="upload-progress" value="0" max="100"></progress>
                 </div>
             </div>
             <div class="subcontent hidden" id="box-settings">

--- a/server/dashboard/static/index.html
+++ b/server/dashboard/static/index.html
@@ -71,7 +71,7 @@
                     <p><a href="#" id="settings-blenderupload-start">Upload new blender.tar.xz</a></p>
                 </div>
                 <div id="settings-blenderupload-box" class="hidden">
-                    <form ref="blenderupload-form" id="blenderupload-form" method="post" action="#" enctype="multipart/form-data">
+                    <form ref="blenderupload-form" id="settings-blenderupload-form" method="post" action="#" enctype="multipart/form-data">
                         <label for="settings-blenderfile">Blender.tar.xz (from blender.org): </label>
                         <input type="file" id="settings-blenderfile" name="settings-blenderfile" accept=".tar.xz"/>
                         <br>
@@ -80,9 +80,9 @@
                     </form>
                 </div>
                 <div id="settings-uploading-box" class="hidden">
-                    <p>Uploading...</p>
+                    <p id="settings-uploading-progress-message">Uploading...</p>
                     <br>
-                    <progress id="blenderupload-progress" value="0" max="100"></progress>
+                    <progress id="settings-uploading-progress" value="0" max="100"></progress>
                 </div>
             </div>
         </div>

--- a/server/dashboard/static/index.html
+++ b/server/dashboard/static/index.html
@@ -21,14 +21,14 @@
                 <div id="workers-list"></div>
             </div>
             <div class="subcontent hidden" id="box-upload">
-                <form ref="uploadform" id="uploadform" method="post" enctype="multipart/form-data">
+                <form ref="uploadform" id="uploadform" method="post" action="#" enctype="multipart/form-data">
                     <div id="upload-upload-box">
                         <label for="upload-file">File Upload (.zip of blend file and assets): </label>
                         <input type="file" name="upload-file" id="upload-file" accept="application/zip"/>
                         <br>
                         <input type="button" id="upload-upload-submit" value="Next"/>
                         <br>
-                        <p>Make sure to have the blender file set to relative paths (File > Relative Paths).</p>
+                        <p>Make sure to have the blender file set to relative paths (File > External Data > Make All Paths Relative).</p>
                         <p>All fluid cache, external images, etc should be included in the zip file as well.</p>
                     </div>
                     <div id="upload-loading-box" class="hidden">
@@ -55,10 +55,9 @@
                         <label for="upload-cutinto">Split image into x by x chunks: </label>
                         <input type="number" name="upload-cutinto" id="upload-cutinto" value="2" max="8"/>
                         <br>
-                        <input type="submit" id="upload-config-submit" value="Submit"/>
-                        <br>
                         <p>2 Is the recommended split chunks level (this will turn every image into 4 quarters to be rendered)</p>
                         <p>Having this set too high can actually increase the time taken to render because of all the initialization needed to be done before the start of the render.</p>
+                        <input type="button" id="upload-config-submit" value="Submit"/>
                     </div>
                 </form>
                 <div id="upload-uploading-box" class="hidden">

--- a/server/dashboard/static/index.html
+++ b/server/dashboard/static/index.html
@@ -71,16 +71,18 @@
                     <p><a href="#" id="settings-blenderupload-start">Upload new blender.tar.xz</a></p>
                 </div>
                 <div id="settings-blenderupload-box" class="hidden">
-                    <label for="settings-blenderfile">Blender.tar.xz (from blender.org): </label>
-                    <input type="file" id="settings-blenderfile" name="settings-blenderfile" accept=".tar.xz"/>
-                    <br>
-                    <p>Make sure the binary is the same architecture as the worker nodes</p>
-                    <input type="button" id="settings-blenderupload-submit" value="Submit"/>
+                    <form ref="blenderupload-form" id="blenderupload-form" method="post" action="#" enctype="multipart/form-data">
+                        <label for="settings-blenderfile">Blender.tar.xz (from blender.org): </label>
+                        <input type="file" id="settings-blenderfile" name="settings-blenderfile" accept=".tar.xz"/>
+                        <br>
+                        <p>Make sure the binary is the same architecture as the worker nodes</p>
+                        <input type="button" id="settings-blenderupload-submit" value="Submit"/>
+                    </form>
                 </div>
                 <div id="settings-uploading-box" class="hidden">
                     <p>Uploading...</p>
                     <br>
-                    <img src="loading.gif"/>
+                    <progress id="blenderupload-progress" value="0" max="100"></progress>
                 </div>
             </div>
         </div>

--- a/server/dashboard/static/index.html
+++ b/server/dashboard/static/index.html
@@ -21,44 +21,46 @@
                 <div id="workers-list"></div>
             </div>
             <div class="subcontent hidden" id="box-upload">
-                <div id="upload-upload-box">
-                    <label for="upload-file">File Upload (.zip of blend file and assets): </label>
-                    <input type="file" name="upload-file" id="upload-file" accept="application/zip"/>
-                    <br>
-                    <input type="button" id="upload-upload-submit" value="Next"/>
-                    <br>
-                    <p>Make sure to have the blender file set to relative paths (File > Relative Paths).</p>
-                    <p>All fluid cache, external images, etc should be included in the zip file as well.</p>
-                </div>
-                <div id="upload-loading-box" class="hidden">
-                    <p>Loading...</p>
-                    <br>
-                    <img src="loading.gif"/>
-                </div>
-                <div id="upload-config-box" class="hidden">
-                    <label for="upload-blendfile">Blender file to be rendered: </label>
-                    <select name="upload-blendfile" id="upload-blendfile"></select>
-                    <br>
-                    <label for="upload-title">Title: </label>
-                    <input type="text" name="upload-title" id="upload-title"></input>
-                    <br>
-                    <label for="upload-animation">Animation: </label>
-                    <input type="checkbox" name="upload-animation" id="upload-animation"/>
-                    <br>
-                    <label for="upload-framestart" id="upload-framestart-label">Frame to render: </label>
-                    <input type="number" name="upload-framestart" id="upload-framestart" value="1"/>
-                    <br>
-                    <label for="upload-frameend" id="upload-frameend-label" class="hidden">End frame of animation: </label>
-                    <input type="number" name="upload-frameend" id="upload-frameend" class="hidden"/>
-                    <br>
-                    <label for="upload-cutinto">Split image into x by x chunks: </label>
-                    <input type="number" name="upload-cutinto" id="upload-cutinto" value="2" max="8"/>
-                    <br>
-                    <input type="button" id="upload-config-submit" value="Submit"/>
-                    <br>
-                    <p>2 Is the recommended split chunks level (this will turn every image into 4 quarters to be rendered)</p>
-                    <p>Having this set too high can actually increase the time taken to render because of all the initialization needed to be done before the start of the render.</p>
-                </div>
+                <form ref="uploadform" id="uploadform" method="post" enctype="multipart/form-data">
+                    <div id="upload-upload-box">
+                        <label for="upload-file">File Upload (.zip of blend file and assets): </label>
+                        <input type="file" name="upload-file" id="upload-file" accept="application/zip"/>
+                        <br>
+                        <input type="button" id="upload-upload-submit" value="Next"/>
+                        <br>
+                        <p>Make sure to have the blender file set to relative paths (File > Relative Paths).</p>
+                        <p>All fluid cache, external images, etc should be included in the zip file as well.</p>
+                    </div>
+                    <div id="upload-loading-box" class="hidden">
+                        <p>Loading...</p>
+                        <br>
+                        <img src="loading.gif"/>
+                    </div>
+                    <div id="upload-config-box" class="hidden">
+                        <label for="upload-blendfile">Blender file to be rendered: </label>
+                        <select name="upload-blendfile" id="upload-blendfile"></select>
+                        <br>
+                        <label for="upload-title">Title: </label>
+                        <input type="text" name="upload-title" id="upload-title"></input>
+                        <br>
+                        <label for="upload-animation">Animation: </label>
+                        <input type="checkbox" name="upload-animation" id="upload-animation"/>
+                        <br>
+                        <label for="upload-framestart" id="upload-framestart-label">Frame to render: </label>
+                        <input type="number" name="upload-framestart" id="upload-framestart" value="1"/>
+                        <br>
+                        <label for="upload-frameend" id="upload-frameend-label" class="hidden">End frame of animation: </label>
+                        <input type="number" name="upload-frameend" id="upload-frameend" class="hidden"/>
+                        <br>
+                        <label for="upload-cutinto">Split image into x by x chunks: </label>
+                        <input type="number" name="upload-cutinto" id="upload-cutinto" value="2" max="8"/>
+                        <br>
+                        <input type="submit" id="upload-config-submit" value="Submit"/>
+                        <br>
+                        <p>2 Is the recommended split chunks level (this will turn every image into 4 quarters to be rendered)</p>
+                        <p>Having this set too high can actually increase the time taken to render because of all the initialization needed to be done before the start of the render.</p>
+                    </div>
+                </form>
                 <div id="upload-uploading-box" class="hidden">
                     <p>Uploading...</p>
                     <br>

--- a/server/dashboard/ts/settings.ts
+++ b/server/dashboard/ts/settings.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { AxiosRequestConfig } from "axios";
 import {apiurl, networkOptions} from "./networking";
 import {base64ArrayBuffer} from "./b64";
 
@@ -8,6 +8,7 @@ let mainBox = document.getElementById("settings-main-box")!;
 let blenderuploadStart = document.getElementById("settings-blenderupload-start")!;
 
 let blenderuploadBox = document.getElementById("settings-blenderupload-box")!;
+let blenderuploadForm = document.getElementById("settings-blenderupload-form")! as HTMLFormElement;
 let blenderfile = document.getElementById("settings-blenderfile")! as HTMLInputElement;
 let blenderuploadSubmit = document.getElementById("settings-blenderupload-submit")! as HTMLInputElement;
 
@@ -34,6 +35,16 @@ export default async function settings() {
             window.location.reload();
         }
 
+        let formData = new FormData(blenderuploadForm);
+
+        let options:AxiosRequestConfig = networkOptions();
+        options.headers = {
+            "Content-Type": "multipart/form-data"
+        }
+
+
+
+        /*
         const fileReader = new FileReader();
         fileReader.readAsArrayBuffer(blenderfile.files![0]);
 
@@ -47,12 +58,12 @@ export default async function settings() {
         }
 
         console.log("Uploading blender...");
-        let res:types.UploadBlenderResponse = (await axios.post(`${apiurl()}/api/uploadblender`, request, networkOptions())).data;
+        let res:types.UploadBlenderResponse = (await axios.post(`${apiurl()}/api/uploadblender`, request, networkOptions())).data;*/
 
-        if(!res.success) {
+        /*if(!res.success) {
             alert(res.message);
             window.location.reload();
-        }
+        }*/
 
         alert("Success!!");
         window.location.reload();

--- a/server/dashboard/ts/settings.ts
+++ b/server/dashboard/ts/settings.ts
@@ -13,6 +13,9 @@ let blenderfile = document.getElementById("settings-blenderfile")! as HTMLInputE
 let blenderuploadSubmit = document.getElementById("settings-blenderupload-submit")! as HTMLInputElement;
 
 let uploadingBox = document.getElementById("settings-uploading-box")!;
+let uploadingProgress = document.getElementById("settings-uploading-progress")! as HTMLProgressElement;
+let uploadingProgressMessage = document.getElementById("settings-uploading-progress-message")!;
+
 
 let done = false;
 
@@ -42,28 +45,19 @@ export default async function settings() {
             "Content-Type": "multipart/form-data"
         }
 
-
-
-        /*
-        const fileReader = new FileReader();
-        fileReader.readAsArrayBuffer(blenderfile.files![0]);
-
-        let blenderTarXz:ArrayBuffer = await new Promise(resolve => {fileReader.onload = e => {
-            resolve(fileReader.result as unknown as ArrayBuffer);
-        }});
-
-        console.log("Converting blender...");
-        let request:types.UploadBlenderRequest = {
-            data: base64ArrayBuffer(blenderTarXz)
+        options.onUploadProgress = e => {
+            let currentPercentage = Math.round((e.loaded * 100) / e.total!);
+            uploadingProgress.value = currentPercentage;
+            uploadingProgressMessage.innerHTML = `Uploading... ${currentPercentage}%`;
         }
 
-        console.log("Uploading blender...");
-        let res:types.UploadBlenderResponse = (await axios.post(`${apiurl()}/api/uploadblender`, request, networkOptions())).data;*/
-
-        /*if(!res.success) {
+        let res:types.UploadProjectResponse = (await axios.post(`${apiurl()}/form/uploadblender`,
+                                                                formData,
+                                                                options)).data;
+        if(!res.success) {
             alert(res.message);
             window.location.reload();
-        }*/
+        }
 
         alert("Success!!");
         window.location.reload();

--- a/server/dashboard/ts/upload.ts
+++ b/server/dashboard/ts/upload.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, {AxiosRequestConfig} from "axios";
 import JSZip from "jszip";
 import {apiurl, networkOptions} from "./networking";
 import {base64ArrayBuffer} from "./b64";
@@ -30,8 +30,6 @@ let done = false;
 export default async function upload() {
     if(done) return;
     done = true;
-
-    uploadform.action = `${apiurl()}/form/uploadproject`;
 
     let zip:JSZip = null as unknown as JSZip;
     let zipFile:ArrayBuffer = null as unknown as ArrayBuffer;
@@ -86,20 +84,21 @@ export default async function upload() {
     });
 
     configSubmit?.addEventListener("click", async e => {
-        /*let request:types.UploadProjectRequest = {
-            title: title.value || "unnamed",
-            blendfile: blendfile.value,
-            cutinto: Math.max(parseInt(cutinto.value), 1),
-            animation: animation.checked,
-            framestart: Math.max(parseInt(framestart.value), 1),
-            data: base64ArrayBuffer(zipFile)
-        };
-        if(request.animation) request.frameend = parseInt(frameend.value) + 1;
+        let formData = new FormData(uploadform);
+        console.log(formData);
 
         configBox.classList.add("hidden");
         uploadingBox.classList.remove("hidden");
 
-        let res:types.UploadProjectResponse = (await axios.post(`${apiurl()}/api/uploadproject`, request, networkOptions())).data;
+        let options:AxiosRequestConfig = networkOptions();
+        options.headers = {
+            "Content-Type": "multipart/form-data"
+        }
+        
+
+        let res:types.UploadProjectResponse = (await axios.post(`${apiurl()}/form/uploadproject`,
+                                                                formData,
+                                                                options)).data;
 
         if(!res.success) {
             alert(res.message!);
@@ -107,6 +106,6 @@ export default async function upload() {
         }
 
         alert(`Success!`);
-        window.location.reload();*/
+        window.location.reload();
     });
 }

--- a/server/dashboard/ts/upload.ts
+++ b/server/dashboard/ts/upload.ts
@@ -22,6 +22,8 @@ let cutinto = document.getElementById("upload-cutinto")! as HTMLInputElement;
 let configSubmit = document.getElementById("upload-config-submit");
 
 let uploadingBox = document.getElementById("upload-uploading-box")!;
+let progress = document.getElementById("upload-progress")! as HTMLProgressElement;
+let progressMessage = document.getElementById("upload-progress-message")!;
 
 let uploadform = document.getElementById("uploadform")! as HTMLFormElement;
 
@@ -93,6 +95,12 @@ export default async function upload() {
         let options:AxiosRequestConfig = networkOptions();
         options.headers = {
             "Content-Type": "multipart/form-data"
+        }
+
+        options.onUploadProgress = e => {
+            let currentPercentage = Math.round((e.loaded * 100) / e.total!);
+            progress.value = currentPercentage;
+            progressMessage.innerHTML = `Uploading... ${currentPercentage}%`;
         }
         
 

--- a/server/dashboard/ts/upload.ts
+++ b/server/dashboard/ts/upload.ts
@@ -23,11 +23,15 @@ let configSubmit = document.getElementById("upload-config-submit");
 
 let uploadingBox = document.getElementById("upload-uploading-box")!;
 
+let uploadform = document.getElementById("uploadform")! as HTMLFormElement;
+
 let done = false;
 
 export default async function upload() {
     if(done) return;
     done = true;
+
+    uploadform.action = `${apiurl()}/form/uploadproject`;
 
     let zip:JSZip = null as unknown as JSZip;
     let zipFile:ArrayBuffer = null as unknown as ArrayBuffer;
@@ -82,8 +86,7 @@ export default async function upload() {
     });
 
     configSubmit?.addEventListener("click", async e => {
-
-        let request:types.UploadProjectRequest = {
+        /*let request:types.UploadProjectRequest = {
             title: title.value || "unnamed",
             blendfile: blendfile.value,
             cutinto: Math.max(parseInt(cutinto.value), 1),
@@ -104,6 +107,6 @@ export default async function upload() {
         }
 
         alert(`Success!`);
-        window.location.reload();
+        window.location.reload();*/
     });
 }

--- a/server/dashboard/ts/upload.ts
+++ b/server/dashboard/ts/upload.ts
@@ -87,7 +87,6 @@ export default async function upload() {
 
     configSubmit?.addEventListener("click", async e => {
         let formData = new FormData(uploadform);
-        console.log(formData);
 
         configBox.classList.add("hidden");
         uploadingBox.classList.remove("hidden");

--- a/server/package.json
+++ b/server/package.json
@@ -26,6 +26,7 @@
     "better-sqlite3": "^8.1.0",
     "cors": "^2.8.5",
     "express": "^4.18.2",
+    "express-fileupload": "^1.4.0",
     "imagemagick": "^0.1.3",
     "jsonschema": "^1.4.1",
     "jszip": "^3.10.1",
@@ -38,6 +39,7 @@
   "devDependencies": {
     "@types/cors": "^2.8.13",
     "@types/express": "^4.17.17",
+    "@types/express-fileupload": "^1.4.1",
     "@types/imagemagick": "^0.0.31",
     "@types/nanoid": "^3.0.0",
     "@types/webpack": "^5.28.0",

--- a/server/server/routes/orchestrator.ts
+++ b/server/server/routes/orchestrator.ts
@@ -136,7 +136,7 @@ export default (ctx:Context) => {
 
 
     
-    api.post("/api/uploadblender", fileUpload(), express.urlencoded({extended: true}), async (req, res, next) => {
+    api.post("/form/uploadblender", fileUpload(), express.urlencoded({extended: true}), async (req, res, next) => {
         try {
             if(!req.files || Object.keys(req.files).length < 1) return next();
             if(!req.files["settings-blenderfile"]) return next();

--- a/server/server/routes/orchestrator.ts
+++ b/server/server/routes/orchestrator.ts
@@ -57,8 +57,7 @@ export default (ctx:Context) => {
                 cutinto: parseInt(req.body["upload-cutinto"]),
                 animation: req.body["upload-animation"] ? true : false,
                 framestart: parseInt(req.body["upload-framestart"]),
-                frameend: Number.isNaN(parseInt(req.body["upload-frameend"])) ? 0 : parseInt(req.body["upload-frameend"]) + 1,
-                data: ""
+                frameend: Number.isNaN(parseInt(req.body["upload-frameend"])) ? 0 : parseInt(req.body["upload-frameend"]) + 1
             }
         } catch(err) {
             return next();

--- a/server/server/types/api.ts
+++ b/server/server/types/api.ts
@@ -15,8 +15,7 @@ export interface UploadProjectRequest {
     cutinto:number,
     animation:boolean,
     framestart:number,
-    frameend?:number,
-    data:string
+    frameend?:number
 }
 export interface UploadProjectResponse extends Response {
     projectid:string | number


### PR DESCRIPTION
Previously data was uploaded via json api, but this meant base64 encoding the files to be uploaded. While this is not an issue for small files, because I am an idiot and cannot stream stuff properly (+ json incompatibility), this means reading the entire contents of the file to an array, base64 encoding that array, and then sending it to the server. This causes massive RAM overhead for any file larger than like 10mb
Solution: do it the right way in the first place, using a html form

Implementation: not terrible, not good - just a wrapper to translate input form into what the /api/uploadproject already understands

same was done for upload blender