### PR TITLE
use proper args for python script

### DIFF
--- a/worker/worker/renderer.py
+++ b/worker/worker/renderer.py
@@ -1,17 +1,34 @@
 import bpy
 import os
 import sys
+import argparse
 
 bpy.ops.file.make_paths_relative()
 
-# 0 = directory to render to
-# 1 = frame to render
-# 2 = split into how many per side?
-# 3 = row to render
-# 4 = column to render
+class ArgumentParserForBlender(argparse.ArgumentParser):
+    def _get_argv_after_double_dash(self):
+        try:
+            idx = sys.argv.index("--")
+            return sys.argv[idx + 1:]  # the list after "--"
+        except ValueError as e:  # "--" not in the list:
+            return []
 
-argv = sys.argv
-argv = argv[argv.index("--") + 1:]
+    # overrides superclass
+    def parse_args(self):
+        return super().parse_args(args=self._get_argv_after_double_dash())
+
+
+parser = ArgumentParserForBlender()
+parser.add_argument("-o", "--output", dest="output", type=str, required=True, help="output file")
+parser.add_argument("-t", "--task", dest="task", type=int, required=False, help="Task Id")
+parser.add_argument("-f", "--frame", dest="frame", type=int, required=True, help="Frames to render")
+parser.add_argument("-r", "--row", dest="row", type=int, required=True, help="Row coordinate")
+parser.add_argument("-cl", "--column", dest="column", type=int, required=True, help="Column coordinate")
+parser.add_argument('-ca', "--camera", dest="camera", type=str, required=False, help="Camera name")
+parser.add_argument('-ci', "--cut-into", dest="cut_into", type=str, required=False, help="Camera name")
+
+parsed = parser.parse_args()
+
 
 scene = bpy.context.scene
 rndr = scene.render
@@ -19,14 +36,14 @@ rndr = scene.render
 rndr.use_border = True # we only want to render a specific portion of the image
 rndr.use_crop_to_border = False # but at the same time we do not want to crop the image to these dimensions (makes it easier to composite, now images can just be stacked ontop of one another)
 
-rndr.filepath = os.path.join(argv[0], "out")
+rndr.filepath = os.path.join(parsed.output, "out")
 
-scene.frame_set(int(argv[1]))
+scene.frame_set(int(parsed.frame))
 
 # set boundaries for render
-cut_into = int(argv[2])
-row = int(argv[3])
-column = int(argv[4])
+cut_into = int(parsed.cut_into)
+row = int(parsed.row)
+column = int(parsed.column)
 
 rndr.border_min_x = (1 / cut_into) * row
 rndr.border_max_x = (1 / cut_into) * (row + 1)
@@ -42,10 +59,11 @@ bpy.ops.render.render(write_still = True)
 #                                                                   column
 
 try:
-    os.remove(os.path.join(argv[0], "renderdata")) # let us try to remove the old renderdata
+    os.remove(os.path.join(parsed.output, "renderdata"))  # let us try to remove the old renderdata
 except OSError:
     pass
 
-f = open(os.path.join(argv[0], "renderdata"), "w")
-f.write("{}\n{}".format(rndr.fps, rndr.fps_base)) # fps is the frames per second in a render, fps_base is the multiplier
+f = open(os.path.join(parsed.output, "renderdata"), "w")
+f.write(
+    "{}\n{}".format(rndr.fps, rndr.fps_base))  # fps is the frames per second in a render, fps_base is the multiplier
 f.close()

--- a/worker/worker/worker.ts
+++ b/worker/worker/worker.ts
@@ -307,11 +307,11 @@ log(`I am ${name}`);
                 "-b", path.join(TEMP_DIR, `${job.dataid}`, job.blendfile), // the blender file is here
                 "-P", "worker/renderer.py", // the script is here
                 "--", // options for the script
-                TEMP_DIR, // where to save out.whatever
-                job.frame.toString(), // frame
-                job.cutinto.toString(), // what to split into?
-                job.row.toString(), // what row to render
-                job.column.toString() // what column to render
+                "-o", TEMP_DIR, // where to save out.whatever
+                "-f", job.frame.toString(), // frame
+                "-ci", job.cutinto.toString(), // what to split into?
+                "-r", job.row.toString(), // what row to render
+                "-cl", job.column.toString() // what column to render
             ]);
 
             blender.stdout.on("data", data => {


### PR DESCRIPTION
Added a simple class to renderer.py , which gives the ablility for easier pass for args + ignore the order of passed arguments passed  to spawn command.

this eliminates the nessesary of command order sequence to blender.